### PR TITLE
Remove custom python-for-android source directory

### DIFF
--- a/buildozer.spec
+++ b/buildozer.spec
@@ -53,7 +53,6 @@ android.ndk_api = 21
 # SDK path configuration
 android.sdk_path = ~/Android/Sdk
 android.ndk_path = ~/Android/Sdk/ndk/25.2.9519653
-p4a.source_dir = /home/xavicq/gestor-tareas/.buildozer/android/platform/python-for-android
 android.archs = arm64-v8a, armeabi-v7a
 
 # Configuración de compilación


### PR DESCRIPTION
## Summary
- delete the hard-coded `p4a.source_dir` entry from `buildozer.spec` so python-for-android is fetched normally

## Testing
- buildozer android debug *(fails: pyjnius Cython build errors — `long` name undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b0b04010832183a2b6ad2e1a5a06