### PR TITLE
Ajusta dependencias de Buildozer y documentación

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,9 @@ python3 -m venv venv
 source venv/bin/activate
 ```
 
-3. Instalar dependencias:
+3. Instalar dependencias (misma pila que se usa para compilar con Buildozer):
 ```bash
-pip install kivy==2.2.1
-pip install pillow
-pip install pytz
+pip install "cython==0.29.33" "kivy==2.2.1" "pytz"
 ```
 
 ## Ejecución
@@ -95,6 +93,8 @@ sudo apt install -y python3-dev build-essential libssl-dev libffi-dev libltdl-de
 ```bash
 pip install buildozer
 ```
+
+> **Nota:** Buildozer usa las dependencias definidas en `buildozer.spec`, por lo que el APK se compila con `cython==0.29.33`, `kivy==2.2.1` y `pytz`, la misma pila que se instala para desarrollo.
 
 3. Compilar APK:
 ```bash

--- a/buildozer.spec
+++ b/buildozer.spec
@@ -30,12 +30,8 @@ version = 1.0.0
 
 # Requerimientos (todos los paquetes necesarios para la app)
 requirements = python3,
-    cython==3.0.0,
-    setuptools,
-    wheel,
-    kivy==2.3.0,
-    pillow,
-    sqlite3,
+    cython==0.29.33,
+    kivy==2.2.1,
     pytz
 
 p4a.branch = develop

--- a/requirements
+++ b/requirements
@@ -1,6 +1,0 @@
-requirements = python3,
-    cython==0.29.33,
-    kivy==2.2.1,
-    pillow,
-    sqlite3,
-    pytz


### PR DESCRIPTION
## Summary
- actualiza los requirements en buildozer.spec para usar cython 0.29.33 y kivy 2.2.1
- elimina el archivo requirements duplicado
- alinea la guía de instalación del README con la pila usada en compilación

## Testing
- no se ejecutaron pruebas (no solicitadas)


------
https://chatgpt.com/codex/tasks/task_e_68d3043a0cd88321aa332acc0eb24fe5