### PR TITLE
Remove hardcoded Android SDK paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,17 @@ sudo apt install -y python3-dev build-essential libssl-dev libffi-dev libltdl-de
 pip install buildozer
 ```
 
-3. Compilar APK:
+3. Preparar el entorno de Android:
+   - Buildozer descargará automáticamente el SDK y el NDK en la carpeta `.buildozer/android` la primera vez que ejecutes un comando de compilación.
+   - Si ya tienes una instalación existente, exporta las variables de entorno antes de compilar para que Buildozer las detecte:
+     ```bash
+     export ANDROIDSDK_HOME="/ruta/a/Android/Sdk"
+     export ANDROIDNDK_HOME="$ANDROIDSDK_HOME/ndk/25.2.9519653"
+     ```
+
+4. Limpiar y compilar el APK:
 ```bash
+buildozer android clean
 buildozer android debug
 ```
 

--- a/buildozer.spec
+++ b/buildozer.spec
@@ -56,9 +56,9 @@ android.minapi = 21
 android.ndk = 25b
 android.ndk_api = 21
 
-# SDK path configuration
-android.sdk_path = /home/xavicq/Android/Sdk
-android.ndk_path = /home/xavicq/Android/Sdk/ndk/25.2.9519653
+# SDK path configuration (Buildozer descargará o detectará el SDK/NDK automáticamente)
+#android.sdk_path = /home/xavicq/Android/Sdk
+#android.ndk_path = /home/xavicq/Android/Sdk/ndk/25.2.9519653
 android.archs = arm64-v8a, armeabi-v7a
 
 # Configuración de compilación


### PR DESCRIPTION
## Summary
- comment the hardcoded Android SDK/NDK paths in `buildozer.spec` so Buildozer can autodetect the installed toolchain
- document in the README how Buildozer downloads the Android SDK/NDK and how to point to an existing installation via environment variables
- add build instructions that clean before building the debug APK

## Testing
- `buildozer android clean` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d304391cf88321a6206176dde4b220