### PR TITLE
Use python-for-android stable branch

### DIFF
--- a/buildozer.spec
+++ b/buildozer.spec
@@ -38,7 +38,7 @@ requirements = python3,
     sqlite3,
     pytz
 
-p4a.branch = develop
+# p4a.branch = develop
 
 # Orientación (portrait para móviles)
 orientation = portrait


### PR DESCRIPTION
## Summary
- comment out the custom python-for-android branch so buildozer falls back to the stable default

## Testing
- `~/.local/bin/buildozer android clean`
- `~/.local/bin/buildozer android debug` *(fails: download of freetype recipe blocked by corporate proxy - HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d3043a14c483219f42c20de2174ec0